### PR TITLE
Trim incoming messages

### DIFF
--- a/SA2VsChatNET/SA2VsChat.cs
+++ b/SA2VsChatNET/SA2VsChat.cs
@@ -1017,8 +1017,8 @@ namespace SA2VsChatNET
 		public static void ProcessMessage(string message, string userName)
 		{
 			userName = userName.ToLowerInvariant();
-			message = message.ToLowerInvariant();
-		   // Console.WriteLine("From: {0} - Message:{1} ", channelName, msg);
+			message = message.ToLowerInvariant().Trim();
+			// Console.WriteLine("From: {0} - Message:{1} ", channelName, msg);
 			if (userName == "streamlabs")
 			{
 


### PR DESCRIPTION
We had issues setting the mod up on our stream. While this wasn't the main issue, once I got it working the messages contained additional line breaks, either due to a change on Twitch's side or my changes. 
This PR aims to fix that issue. 

The fix for our specific setup might follow in the future as a config option.